### PR TITLE
Implement user registration

### DIFF
--- a/foodfornow-backend/src/routes/auth.js
+++ b/foodfornow-backend/src/routes/auth.js
@@ -64,6 +64,13 @@ router.post('/register', async (req, res) => {
       return res.status(400).json({ error: 'Password must be at least 8 characters' });
     }
 
+    // Enforce strong password: at least one lowercase, one uppercase, one digit, and one special character
+    const strongPasswordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
+    if (!strongPasswordRegex.test(password)) {
+      console.log('Weak password provided');
+      return res.status(400).json({ error: 'Password is too weak' });
+    }
+
     // Validate email format
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     if (!emailRegex.test(email)) {

--- a/foodfornow-frontend/src/pages/Login.jsx
+++ b/foodfornow-frontend/src/pages/Login.jsx
@@ -111,6 +111,13 @@ const Login = () => {
             >
               Sign In
             </Button>
+            <Button
+              fullWidth
+              variant="text"
+              onClick={() => navigate('/register')}
+            >
+              Don't have an account? Register
+            </Button>
           </Box>
         </Paper>
       </Box>

--- a/foodfornow-frontend/src/pages/Register.jsx
+++ b/foodfornow-frontend/src/pages/Register.jsx
@@ -20,12 +20,27 @@ const Register = () => {
     confirmPassword: '',
   });
   const [error, setError] = useState('');
+  const [passwordStrength, setPasswordStrength] = useState('');
+
+  const evaluatePassword = (pwd) => {
+    const strongRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
+    const mediumRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{8,}$/;
+
+    if (strongRegex.test(pwd)) return 'strong';
+    if (mediumRegex.test(pwd)) return 'medium';
+    if (pwd) return 'weak';
+    return '';
+  };
 
   const handleChange = (e) => {
+    const { name, value } = e.target;
     setFormData({
       ...formData,
-      [e.target.name]: e.target.value,
+      [name]: value,
     });
+    if (name === 'password') {
+      setPasswordStrength(evaluatePassword(value));
+    }
   };
 
   const handleSubmit = async (e) => {
@@ -41,6 +56,13 @@ const Register = () => {
     // Validate password length
     if (formData.password.length < 8) {
       setError('Password must be at least 8 characters long');
+      return;
+    }
+
+    // Ensure password strength is not weak
+    const strongRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
+    if (!strongRegex.test(formData.password)) {
+      setError('Password is too weak');
       return;
     }
 
@@ -139,6 +161,21 @@ const Register = () => {
               value={formData.password}
               onChange={handleChange}
             />
+            {passwordStrength && (
+              <Typography
+                variant="body2"
+                sx={{
+                  color:
+                    passwordStrength === 'strong'
+                      ? 'green'
+                      : passwordStrength === 'medium'
+                      ? 'orange'
+                      : 'red',
+                }}
+              >
+                Password strength: {passwordStrength}
+              </Typography>
+            )}
             <TextField
               margin="normal"
               required


### PR DESCRIPTION
## Summary
- enforce strong password server-side
- add password strength indicator when registering
- link to registration from login page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` in frontend *(fails: Missing script)*
- `npm test` in backend *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b8c0e31e48321a286fdbeec7afe84