### PR TITLE
Add global token refresh interceptor

### DIFF
--- a/foodfornow-frontend/src/pages/Ingredients.jsx
+++ b/foodfornow-frontend/src/pages/Ingredients.jsx
@@ -65,7 +65,7 @@ const Ingredients = () => {
         await api.get('/auth/me');
         fetchIngredients();
       } catch {
-        navigate('/login');
+        // Redirect handled globally by interceptor
       }
     };
     checkAuthAndFetch();
@@ -90,12 +90,7 @@ const Ingredients = () => {
       setIngredients(response.data);
     } catch (err) {
       console.error('Error fetching ingredients:', err);
-      if (err.response?.status === 401) {
-        localStorage.removeItem('token');
-        navigate('/login');
-      } else {
-        setError('Failed to fetch ingredients. Please try again.');
-      }
+      setError('Failed to fetch ingredients. Please try again.');
     } finally {
       setLoading(false);
     }

--- a/foodfornow-frontend/src/pages/Pantry.jsx
+++ b/foodfornow-frontend/src/pages/Pantry.jsx
@@ -61,7 +61,7 @@ const Pantry = () => {
         fetchPantryItems();
         fetchIngredients();
       } catch {
-        navigate('/login');
+        // Redirect handled globally by interceptor
       }
     };
     checkAuthAndFetch();
@@ -192,9 +192,6 @@ const Pantry = () => {
       
       if (err.response?.data?.error) {
         setError(err.response.data.error);
-      } else if (err.response?.status === 401) {
-        setError('Your session has expired. Please log in again.');
-        navigate('/login');
       } else {
         setError('Failed to save pantry item. Please try again.');
       }

--- a/foodfornow-frontend/src/pages/Recipes.jsx
+++ b/foodfornow-frontend/src/pages/Recipes.jsx
@@ -189,12 +189,7 @@ const Recipes = () => {
       });
       setRecipes(response.data);
     } catch (err) {
-      if (err.response?.status === 401) {
-        localStorage.removeItem('token');
-        navigate('/login');
-      } else {
-        setError('Failed to fetch recipes. Please try again.');
-      }
+      setError('Failed to fetch recipes. Please try again.');
     }
   };
 
@@ -203,12 +198,7 @@ const Recipes = () => {
       const response = await api.get('/ingredients');
       setIngredients(response.data);
     } catch (err) {
-      if (err.response?.status === 401) {
-        localStorage.removeItem('token');
-        navigate('/login');
-      } else {
-        setError('Failed to fetch ingredients. Please try again.');
-      }
+      setError('Failed to fetch ingredients. Please try again.');
     }
   };
 
@@ -229,12 +219,7 @@ const Recipes = () => {
         fetchRecipes();
         fetchIngredients();
       } catch (err) {
-        if (err.response?.status === 401) {
-          localStorage.removeItem('token');
-          navigate('/login');
-        } else {
-          setError('Failed to fetch data. Please try again.');
-        }
+        setError('Failed to fetch data. Please try again.');
       } finally {
         setLoading(false);
       }


### PR DESCRIPTION
## Summary
- create Axios response interceptor to refresh auth token
- rely on interceptor instead of page-level 401 handling

## Testing
- `npm run lint -w foodfornow-frontend` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6851723dd85c832195a7c3d3fdac1c3e