### PR TITLE
Conditionally enable React StrictMode

### DIFF
--- a/foodfornow-frontend/src/main.jsx
+++ b/foodfornow-frontend/src/main.jsx
@@ -1,10 +1,17 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.jsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import App from './App.jsx';
 
-createRoot(document.getElementById('root')).render(
+const rootElement = document.getElementById('root');
+const root = createRoot(rootElement);
+
+const element = import.meta.env.DEV ? (
   <StrictMode>
     <App />
-  </StrictMode>,
-)
+  </StrictMode>
+) : (
+  <App />
+);
+
+root.render(element);


### PR DESCRIPTION
## Summary
- only wrap `<App/>` in React `<StrictMode>` during development

## Testing
- `npm run -s lint -w foodfornow-frontend` *(fails: Cannot find package '@eslint/js')*
- `npm run -s build -w foodfornow-frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685174e1329c8321844cbff796fd0e61