### PR TITLE
Implement global Auth context

### DIFF
--- a/foodfornow-frontend/src/App.jsx
+++ b/foodfornow-frontend/src/App.jsx
@@ -11,16 +11,18 @@ import ShoppingList from './pages/ShoppingList';
 import PrivateRoute from './components/PrivateRoute';
 import Navbar from './components/Navbar';
 import { ThemeProvider } from './context/ThemeContext';
+import { AuthProvider } from './context/AuthContext';
 import { Toaster } from 'react-hot-toast';
 import Profile from './pages/Profile';
 
 function App() {
   return (
     <ThemeProvider>
-      <Toaster position="top-right" />
-      <Router>
-        <Navbar />
-        <Routes>
+      <AuthProvider>
+        <Toaster position="top-right" />
+        <Router>
+          <Navbar />
+          <Routes>
           <Route path="/login" element={<Login />} />
           <Route path="/register" element={<Register />} />
           <Route
@@ -74,7 +76,8 @@ function App() {
           <Route path="/profile" element={<PrivateRoute><Profile /></PrivateRoute>} />
           <Route path="/" element={<Navigate to="/dashboard" replace />} />
         </Routes>
-      </Router>
+        </Router>
+      </AuthProvider>
     </ThemeProvider>
   );
 }

--- a/foodfornow-frontend/src/components/Navbar.jsx
+++ b/foodfornow-frontend/src/components/Navbar.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import {
   AppBar,
@@ -19,6 +19,7 @@ import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
 import LocalDiningIcon from '@mui/icons-material/LocalDining';
 import ThemeToggle from './ThemeToggle';
 import api from '../services/api';
+import { useAuth } from '../context/AuthContext';
 
 const pages = [
   { name: 'Dashboard', path: '/dashboard', icon: <DashboardIcon /> },
@@ -32,22 +33,7 @@ const Navbar = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const [anchorEl, setAnchorEl] = React.useState(null);
-  const [authenticated, setAuthenticated] = useState(false);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const checkAuth = async () => {
-      try {
-        await api.get('/auth/me');
-        setAuthenticated(true);
-      } catch {
-        setAuthenticated(false);
-      } finally {
-        setLoading(false);
-      }
-    };
-    checkAuth();
-  }, [location.pathname]);
+  const { authenticated, loading, refreshAuth } = useAuth();
 
   const handleMenu = (event) => {
     setAnchorEl(event.currentTarget);
@@ -59,7 +45,7 @@ const Navbar = () => {
 
   const handleLogout = async () => {
     await api.post('/auth/logout');
-    setAuthenticated(false);
+    refreshAuth();
     navigate('/login');
   };
 

--- a/foodfornow-frontend/src/components/PrivateRoute.jsx
+++ b/foodfornow-frontend/src/components/PrivateRoute.jsx
@@ -1,24 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { Navigate } from 'react-router-dom';
-import api from '../services/api';
+import { useAuth } from '../context/AuthContext';
 
 const PrivateRoute = ({ children }) => {
-  const [loading, setLoading] = useState(true);
-  const [authenticated, setAuthenticated] = useState(false);
-
-  useEffect(() => {
-    const checkAuth = async () => {
-      try {
-        await api.get('/auth/me');
-        setAuthenticated(true);
-      } catch (err) {
-        setAuthenticated(false);
-      } finally {
-        setLoading(false);
-      }
-    };
-    checkAuth();
-  }, []);
+  const { authenticated, loading } = useAuth();
 
   if (loading) return null; // or a spinner
   if (!authenticated) return <Navigate to="/login" replace />;

--- a/foodfornow-frontend/src/context/AuthContext.jsx
+++ b/foodfornow-frontend/src/context/AuthContext.jsx
@@ -1,0 +1,37 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import api from '../services/api';
+
+const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+  const [authenticated, setAuthenticated] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  const refreshAuth = async () => {
+    setLoading(true);
+    try {
+      const { data } = await api.get('/auth/me');
+      setUser(data.user);
+      setAuthenticated(true);
+    } catch {
+      setUser(null);
+      setAuthenticated(false);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refreshAuth();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, authenticated, loading, refreshAuth }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/foodfornow-frontend/src/pages/Dashboard.jsx
+++ b/foodfornow-frontend/src/pages/Dashboard.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import {
   Container,
   Grid,
@@ -32,9 +31,9 @@ import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
 import api from '../services/api';
 import MealPlanGrid from '../components/MealPlanGrid';
 import { getCategoryColor } from '../utils/categoryColors';
+import { useAuth } from '../context/AuthContext';
 
 const Dashboard = () => {
-  const navigate = useNavigate();
   const theme = useTheme();
   const [recipes, setRecipes] = useState([]);
   const [mealPlan, setMealPlan] = useState([]);
@@ -50,25 +49,26 @@ const Dashboard = () => {
     recipeId: '',
   });
 
+  const { authenticated } = useAuth();
+
   useEffect(() => {
-    const checkAuthAndFetch = async () => {
+    if (!authenticated) return;
+
+    const fetchAll = async () => {
       try {
         setLoading(true);
-        await api.get('/auth/me');
         await Promise.all([
           fetchRecipes(),
           fetchMealPlan(),
           fetchIngredients()
         ]);
-      } catch (err) {
-        console.error('Auth error:', err);
-        navigate('/login');
       } finally {
         setLoading(false);
       }
     };
-    checkAuthAndFetch();
-  }, [navigate]);
+
+    fetchAll();
+  }, [authenticated]);
 
   const fetchRecipes = async () => {
     try {

--- a/foodfornow-frontend/src/pages/Ingredients.jsx
+++ b/foodfornow-frontend/src/pages/Ingredients.jsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import {
   Container,
   Typography,
@@ -32,6 +31,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import AddIcon from '@mui/icons-material/Add';
 import api from '../services/api';
 import { getCategoryColor } from '../utils/categoryColors';
+import { useAuth } from '../context/AuthContext';
 
 const UNITS = [
   'g', 'kg', 'oz', 'lb', 'ml', 'l', 'cup', 'tbsp', 'tsp', 'piece', 'pinch'
@@ -42,7 +42,6 @@ const CATEGORIES = [
 ];
 
 const Ingredients = () => {
-  const navigate = useNavigate();
   const [ingredients, setIngredients] = useState([]);
   const [error, setError] = useState('');
   const [openDialog, setOpenDialog] = useState(false);
@@ -58,20 +57,10 @@ const Ingredients = () => {
   const [tab, setTab] = useState('mine');
 
   const [searchTerm, setSearchTerm] = useState('');
+  const { authenticated } = useAuth();
 
   useEffect(() => {
-    const checkAuthAndFetch = async () => {
-      try {
-        await api.get('/auth/me');
-        fetchIngredients();
-      } catch {
-        // Redirect handled globally by interceptor
-      }
-    };
-    checkAuthAndFetch();
-  }, [navigate]);
-
-  useEffect(() => {
+    if (!authenticated) return;
     setLoading(true);
     setError('');
     if (tab === 'mine') {
@@ -80,7 +69,7 @@ const Ingredients = () => {
       fetchSharedIngredients();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tab, searchTerm]);
+  }, [tab, searchTerm, authenticated]);
 
   const fetchIngredients = async () => {
     try {

--- a/foodfornow-frontend/src/pages/Pantry.jsx
+++ b/foodfornow-frontend/src/pages/Pantry.jsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import {
   Container,
   Typography,
@@ -34,9 +33,9 @@ import {
 import api from '../services/api';
 import { getCategoryColor } from '../utils/categoryColors';
 import { toast } from 'react-hot-toast';
+import { useAuth } from '../context/AuthContext';
 
 const Pantry = () => {
-  const navigate = useNavigate();
   const [pantryItems, setPantryItems] = useState([]);
   const [error, setError] = useState('');
   const [openDialog, setOpenDialog] = useState(false);
@@ -54,18 +53,22 @@ const Pantry = () => {
   const [loading, setLoading] = useState(true);
   const [openClearConfirmDialog, setOpenClearConfirmDialog] = useState(false);
 
+  const { authenticated } = useAuth();
+
   useEffect(() => {
-    const checkAuthAndFetch = async () => {
+    if (!authenticated) return;
+
+    const fetchAll = async () => {
       try {
-        await api.get('/auth/me');
-        fetchPantryItems();
-        fetchIngredients();
-      } catch {
-        // Redirect handled globally by interceptor
+        setLoading(true);
+        await Promise.all([fetchPantryItems(), fetchIngredients()]);
+      } finally {
+        setLoading(false);
       }
     };
-    checkAuthAndFetch();
-  }, [navigate]);
+
+    fetchAll();
+  }, [authenticated]);
 
   const fetchPantryItems = async () => {
     try {

--- a/foodfornow-frontend/src/pages/Profile.jsx
+++ b/foodfornow-frontend/src/pages/Profile.jsx
@@ -18,9 +18,11 @@ import { toast } from 'react-hot-toast';
 import api from '../services/api';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import CancelIcon from '@mui/icons-material/Cancel';
+import { useAuth } from '../context/AuthContext';
 
 const Profile = () => {
   const navigate = useNavigate();
+  const { user, loading: authLoading, refreshAuth } = useAuth();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [formData, setFormData] = useState({
@@ -55,24 +57,15 @@ const Profile = () => {
   }, [formData.newPassword, formData.confirmPassword]);
 
   useEffect(() => {
-    fetchProfile();
-  }, []);
-
-  const fetchProfile = async () => {
-    try {
-      const response = await api.get('/auth/me');
+    if (!authLoading && user) {
       setFormData(prev => ({
         ...prev,
-        name: response.data.user.name,
-        email: response.data.user.email
+        name: user.name,
+        email: user.email,
       }));
-    } catch (err) {
-      console.error('Error fetching profile:', err);
-      setError('Failed to load profile information');
-    } finally {
       setLoading(false);
     }
-  };
+  }, [authLoading, user]);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -123,6 +116,7 @@ const Profile = () => {
       }));
 
       toast.success('Profile updated successfully');
+      refreshAuth();
     } catch (err) {
       console.error('Error updating profile:', err);
       setError(err.response?.data?.error || 'Failed to update profile');

--- a/foodfornow-frontend/src/pages/ShoppingList.jsx
+++ b/foodfornow-frontend/src/pages/ShoppingList.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import {
   Container,
   Typography,
@@ -37,10 +36,11 @@ import {
 import api from '../services/api';
 import { getCategoryColor } from '../utils/categoryColors';
 import { toast } from 'react-hot-toast';
+import { useAuth } from '../context/AuthContext';
 
 const ShoppingList = () => {
-  const navigate = useNavigate();
   const theme = useTheme();
+  const { authenticated } = useAuth();
   const [shoppingItems, setShoppingItems] = useState([]);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(true);
@@ -56,17 +56,17 @@ const ShoppingList = () => {
   const validUnits = ['g', 'kg', 'oz', 'lb', 'ml', 'l', 'cup', 'tbsp', 'tsp', 'piece', 'pinch'];
 
   useEffect(() => {
-    const checkAuthAndFetch = async () => {
+    if (!authenticated) return;
+    const fetchAll = async () => {
       try {
-        await api.get('/auth/me');
-        fetchShoppingList();
-        fetchIngredients();
-      } catch {
-        navigate('/login');
+        setLoading(true);
+        await Promise.all([fetchShoppingList(), fetchIngredients()]);
+      } finally {
+        setLoading(false);
       }
     };
-    checkAuthAndFetch();
-  }, [navigate]);
+    fetchAll();
+  }, [authenticated]);
 
   const fetchShoppingList = async () => {
     try {


### PR DESCRIPTION
## Summary
- add `AuthContext` for centralized user auth state
- wrap the app with `AuthProvider`
- replace page-level auth checks with `useAuth`

## Testing
- `npm run lint -w foodfornow-frontend` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685174c6d4208321becc54bc0a81b262