### PR TITLE
Improve error message surfacing

### DIFF
--- a/foodfornow-backend/src/routes/ingredients.js
+++ b/foodfornow-backend/src/routes/ingredients.js
@@ -17,7 +17,7 @@ router.get('/', authMiddleware, async (req, res) => {
     res.json(ingredients);
   } catch (err) {
     console.error('Error fetching ingredients:', err);
-    res.status(500).json({ message: 'Error fetching ingredients' });
+    res.status(500).json({ error: 'Error fetching ingredients' });
   }
 });
 
@@ -50,7 +50,7 @@ router.get('/shared', authMiddleware, async (req, res) => {
     res.json(sharedIngredients);
   } catch (err) {
     console.error('Error fetching shared ingredients:', err);
-    res.status(500).json({ message: 'Error fetching shared ingredients' });
+    res.status(500).json({ error: 'Error fetching shared ingredients' });
   }
 });
 
@@ -59,12 +59,12 @@ router.post('/:id/duplicate', authMiddleware, async (req, res) => {
   try {
     const original = await Ingredient.findById(req.params.id);
     if (!original) {
-      return res.status(404).json({ message: 'Ingredient not found' });
+      return res.status(404).json({ error: 'Ingredient not found' });
     }
     // Prevent duplicating if user already has this ingredient
     const existing = await Ingredient.findOne({ user: req.userId, name: original.name });
     if (existing) {
-      return res.status(409).json({ message: 'You already have this ingredient in your collection' });
+      return res.status(409).json({ error: 'You already have this ingredient in your collection' });
     }
     const duplicate = new Ingredient({
       name: original.name,
@@ -78,7 +78,7 @@ router.post('/:id/duplicate', authMiddleware, async (req, res) => {
     res.status(201).json(duplicate);
   } catch (err) {
     console.error('Error duplicating ingredient:', err);
-    res.status(500).json({ message: 'Error duplicating ingredient' });
+    res.status(500).json({ error: 'Error duplicating ingredient' });
   }
 });
 
@@ -94,7 +94,7 @@ router.post('/', authMiddleware, async (req, res) => {
     res.status(201).json(ingredient);
   } catch (err) {
     console.error('Error adding ingredient:', err);
-    res.status(500).json({ message: 'Error adding ingredient' });
+    res.status(500).json({ error: 'Error adding ingredient' });
   }
 });
 
@@ -108,12 +108,12 @@ router.put('/:id', authMiddleware, async (req, res) => {
       { new: true }
     );
     if (!ingredient) {
-      return res.status(404).json({ message: 'Ingredient not found' });
+      return res.status(404).json({ error: 'Ingredient not found' });
     }
     res.json(ingredient);
   } catch (err) {
     console.error('Error updating ingredient:', err);
-    res.status(500).json({ message: 'Error updating ingredient' });
+    res.status(500).json({ error: 'Error updating ingredient' });
   }
 });
 
@@ -128,7 +128,7 @@ router.delete('/:id', authMiddleware, async (req, res) => {
       user: req.userId
     });
     if (!ingredient) {
-      return res.status(404).json({ message: 'Ingredient not found' });
+      return res.status(404).json({ error: 'Ingredient not found' });
     }
 
     // Check if the ingredient is referenced by any of the user's recipes
@@ -137,14 +137,14 @@ router.delete('/:id', authMiddleware, async (req, res) => {
       'ingredients.ingredient': req.params.id
     });
     if (inUse) {
-      return res.status(400).json({ message: 'Cannot delete ingredient: it is used in a recipe' });
+      return res.status(400).json({ error: 'Cannot delete ingredient: it is used in a recipe' });
     }
 
     await ingredient.deleteOne();
     res.json({ message: 'Ingredient deleted' });
   } catch (err) {
     console.error('Error deleting ingredient:', err);
-    res.status(500).json({ message: 'Error deleting ingredient' });
+    res.status(500).json({ error: 'Error deleting ingredient' });
   }
 });
 

--- a/foodfornow-backend/src/routes/shopping-list.js
+++ b/foodfornow-backend/src/routes/shopping-list.js
@@ -18,7 +18,7 @@ router.get('/', authMiddleware, async (req, res) => {
     res.json(items);
   } catch (err) {
     console.error('Error fetching shopping list:', err);
-    res.status(500).json({ message: 'Error fetching shopping list' });
+    res.status(500).json({ error: 'Error fetching shopping list' });
   }
 });
 
@@ -238,7 +238,7 @@ router.put('/:id/toggle', authMiddleware, async (req, res) => {
     });
 
     if (!item) {
-      return res.status(404).json({ message: 'Item not found' });
+      return res.status(404).json({ error: 'Item not found' });
     }
 
     item.completed = !item.completed;
@@ -247,7 +247,7 @@ router.put('/:id/toggle', authMiddleware, async (req, res) => {
     res.json(item);
   } catch (err) {
     console.error('Error toggling item:', err);
-    res.status(500).json({ message: 'Error toggling item' });
+    res.status(500).json({ error: 'Error toggling item' });
   }
 });
 
@@ -261,13 +261,13 @@ router.delete('/:id', authMiddleware, async (req, res) => {
     });
 
     if (!item) {
-      return res.status(404).json({ message: 'Item not found' });
+      return res.status(404).json({ error: 'Item not found' });
     }
 
     res.json({ message: 'Item removed from shopping list' });
   } catch (err) {
     console.error('Error removing item:', err);
-    res.status(500).json({ message: 'Error removing item' });
+    res.status(500).json({ error: 'Error removing item' });
   }
 });
 
@@ -282,7 +282,7 @@ router.delete('/clear-completed', authMiddleware, async (req, res) => {
     res.json({ message: 'Completed items cleared' });
   } catch (err) {
     console.error('Error clearing completed items:', err);
-    res.status(500).json({ message: 'Error clearing completed items' });
+    res.status(500).json({ error: 'Error clearing completed items' });
   }
 });
 
@@ -295,12 +295,12 @@ router.patch('/:id', authMiddleware, async (req, res) => {
       { new: true }
     );
     if (!item) {
-      return res.status(404).json({ message: 'Item not found' });
+      return res.status(404).json({ error: 'Item not found' });
     }
     res.json(item);
   } catch (err) {
     console.error('Error updating shopping list item:', err);
-    res.status(500).json({ message: 'Error updating shopping list item' });
+    res.status(500).json({ error: 'Error updating shopping list item' });
   }
 });
 

--- a/foodfornow-frontend/src/pages/Dashboard.jsx
+++ b/foodfornow-frontend/src/pages/Dashboard.jsx
@@ -29,6 +29,7 @@ import {
 import AddIcon from '@mui/icons-material/Add';
 import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
 import api from '../services/api';
+import { getErrorMessage } from '../utils/errorHandler';
 import MealPlanGrid from '../components/MealPlanGrid';
 import { getCategoryColor } from '../utils/categoryColors';
 import { useAuth } from '../context/AuthContext';
@@ -76,7 +77,7 @@ const Dashboard = () => {
       setRecipes(response.data || []);
     } catch (err) {
       console.error('Error fetching recipes:', err);
-      setError('Failed to fetch recipes. Please try again.');
+      setError(getErrorMessage(err, 'Failed to fetch recipes. Please try again.'));
     }
   };
 
@@ -86,7 +87,7 @@ const Dashboard = () => {
       setMealPlan(response.data || []);
     } catch (err) {
       console.error('Error fetching meal plan:', err);
-      setError('Failed to fetch meal plan. Please try again.');
+      setError(getErrorMessage(err, 'Failed to fetch meal plan. Please try again.'));
     }
   };
 
@@ -107,7 +108,7 @@ const Dashboard = () => {
       }
     } catch (err) {
       console.error('Error fetching ingredients:', err);
-      setError('Failed to fetch ingredients. Please try again.');
+      setError(getErrorMessage(err, 'Failed to fetch ingredients. Please try again.'));
       setIngredients([]);
     }
   };
@@ -121,7 +122,7 @@ const Dashboard = () => {
       await fetchIngredients();
     } catch (err) {
       console.error('Error adding ingredients to shopping list:', err);
-      setError('Failed to add ingredients to shopping list');
+      setError(getErrorMessage(err, 'Failed to add ingredients to shopping list'));
     } finally {
       setLoading(false);
     }
@@ -176,11 +177,7 @@ const Dashboard = () => {
       setError('');
     } catch (err) {
       console.error('Error saving meal:', err);
-      if (err.response?.data?.error) {
-        setError(err.response.data.error);
-      } else {
-        setError('Failed to save meal. Please try again.');
-      }
+      setError(getErrorMessage(err, 'Failed to save meal. Please try again.'));
     } finally {
       setLoading(false);
     }
@@ -200,7 +197,7 @@ const Dashboard = () => {
       ]);
     } catch (err) {
       console.error('Error deleting meal:', err);
-      setError('Failed to delete meal. Please try again.');
+      setError(getErrorMessage(err, 'Failed to delete meal. Please try again.'));
     } finally {
       setLoading(false);
     }

--- a/foodfornow-frontend/src/pages/Ingredients.jsx
+++ b/foodfornow-frontend/src/pages/Ingredients.jsx
@@ -30,6 +30,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
 import AddIcon from '@mui/icons-material/Add';
 import api from '../services/api';
+import { getErrorMessage } from '../utils/errorHandler';
 import { getCategoryColor } from '../utils/categoryColors';
 import { useAuth } from '../context/AuthContext';
 
@@ -77,12 +78,12 @@ const Ingredients = () => {
         params: { search: searchTerm },
       });
       setIngredients(response.data);
-    } catch (err) {
-      console.error('Error fetching ingredients:', err);
-      setError('Failed to fetch ingredients. Please try again.');
-    } finally {
-      setLoading(false);
-    }
+      } catch (err) {
+        console.error('Error fetching ingredients:', err);
+        setError(getErrorMessage(err, 'Failed to fetch ingredients. Please try again.'));
+      } finally {
+        setLoading(false);
+      }
   };
 
   const fetchSharedIngredients = async () => {
@@ -91,12 +92,12 @@ const Ingredients = () => {
         params: { search: searchTerm },
       });
       setIngredients(response.data);
-    } catch (err) {
-      console.error('Error fetching shared ingredients:', err);
-      setError('Failed to fetch shared ingredients. Please try again.');
-    } finally {
-      setLoading(false);
-    }
+      } catch (err) {
+        console.error('Error fetching shared ingredients:', err);
+        setError(getErrorMessage(err, 'Failed to fetch shared ingredients. Please try again.'));
+      } finally {
+        setLoading(false);
+      }
   };
 
   const handleDuplicate = async (id) => {
@@ -104,14 +105,14 @@ const Ingredients = () => {
       await api.post(`/ingredients/${id}/duplicate`);
       setTab('mine');
       setLoading(true);
-    } catch (err) {
-      console.error('Error duplicating ingredient:', err);
-      if (err.response?.status === 409) {
-        setError('You already have this ingredient in your collection.');
-      } else {
-        setError('Failed to add ingredient. Please try again.');
+      } catch (err) {
+        console.error('Error duplicating ingredient:', err);
+        if (err.response?.status === 409) {
+          setError('You already have this ingredient in your collection.');
+        } else {
+          setError(getErrorMessage(err, 'Failed to add ingredient. Please try again.'));
+        }
       }
-    }
   };
 
   const handleOpenDialog = (ingredient = null) => {
@@ -152,20 +153,20 @@ const Ingredients = () => {
       }
       handleCloseDialog();
       fetchIngredients();
-    } catch (err) {
-      console.error('Error saving ingredient:', err);
-      setError('Failed to save ingredient. Please try again.');
-    }
+      } catch (err) {
+        console.error('Error saving ingredient:', err);
+        setError(getErrorMessage(err, 'Failed to save ingredient. Please try again.'));
+      }
   };
 
   const handleDeleteIngredient = async (id) => {
     try {
       await api.delete(`/ingredients/${id}`);
       fetchIngredients();
-    } catch (err) {
-      console.error('Error deleting ingredient:', err);
-      setError('Failed to delete ingredient. Please try again.');
-    }
+      } catch (err) {
+        console.error('Error deleting ingredient:', err);
+        setError(getErrorMessage(err, 'Failed to delete ingredient. Please try again.'));
+      }
   };
 
   const theme = useTheme();

--- a/foodfornow-frontend/src/pages/Pantry.jsx
+++ b/foodfornow-frontend/src/pages/Pantry.jsx
@@ -34,6 +34,7 @@ import api from '../services/api';
 import { getCategoryColor } from '../utils/categoryColors';
 import { toast } from 'react-hot-toast';
 import { useAuth } from '../context/AuthContext';
+import { getErrorMessage } from '../utils/errorHandler';
 
 const Pantry = () => {
   const [pantryItems, setPantryItems] = useState([]);
@@ -82,7 +83,7 @@ const Pantry = () => {
       }
     } catch (err) {
       console.error('Error fetching pantry items:', err);
-      setError('Failed to fetch pantry items. Please try again.');
+      setError(getErrorMessage(err, 'Failed to fetch pantry items. Please try again.'));
     } finally {
       setLoading(false);
     }
@@ -94,7 +95,7 @@ const Pantry = () => {
       setIngredients(response.data);
     } catch (err) {
       console.error('Error fetching ingredients:', err);
-      setError('Failed to fetch ingredients. Please try again.');
+      setError(getErrorMessage(err, 'Failed to fetch ingredients. Please try again.'));
     }
   };
 
@@ -193,11 +194,7 @@ const Pantry = () => {
         status: err.response?.status
       });
       
-      if (err.response?.data?.error) {
-        setError(err.response.data.error);
-      } else {
-        setError('Failed to save pantry item. Please try again.');
-      }
+      setError(getErrorMessage(err, 'Failed to save pantry item. Please try again.'));
     }
   };
 
@@ -207,7 +204,7 @@ const Pantry = () => {
       fetchPantryItems();
     } catch (err) {
       console.error('Error deleting pantry item:', err);
-      setError('Failed to delete pantry item. Please try again.');
+      setError(getErrorMessage(err, 'Failed to delete pantry item. Please try again.'));
     }
   };
 
@@ -217,7 +214,7 @@ const Pantry = () => {
       fetchPantryItems();
     } catch (err) {
       console.error('Error updating quantity:', err);
-      setError('Failed to update quantity. Please try again.');
+      setError(getErrorMessage(err, 'Failed to update quantity. Please try again.'));
     }
   };
 
@@ -227,7 +224,7 @@ const Pantry = () => {
       fetchPantryItems();
     } catch (err) {
       console.error('Error adding to shopping list:', err);
-      setError('Failed to add to shopping list. Please try again.');
+      setError(getErrorMessage(err, 'Failed to add to shopping list. Please try again.'));
     }
   };
 

--- a/foodfornow-frontend/src/pages/RecipeDetail.jsx
+++ b/foodfornow-frontend/src/pages/RecipeDetail.jsx
@@ -19,6 +19,7 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import RestaurantIcon from '@mui/icons-material/Restaurant';
 import TimerIcon from '@mui/icons-material/Timer';
 import api from '../services/api';
+import { getErrorMessage } from '../utils/errorHandler';
 
 const RecipeDetail = () => {
   const { id } = useParams();
@@ -33,7 +34,7 @@ const RecipeDetail = () => {
         setRecipe(response.data);
       } catch (err) {
         console.error('Error fetching recipe:', err);
-        setError('Failed to fetch recipe details. Please try again.');
+        setError(getErrorMessage(err, 'Failed to fetch recipe details. Please try again.'));
       }
     };
 

--- a/foodfornow-frontend/src/pages/Recipes.jsx
+++ b/foodfornow-frontend/src/pages/Recipes.jsx
@@ -33,6 +33,7 @@ import RestaurantIcon from '@mui/icons-material/Restaurant';
 import api from '../services/api';
 import { useTheme } from '@mui/material/styles';
 import { useAuth } from '../context/AuthContext';
+import { getErrorMessage } from '../utils/errorHandler';
 
 const RecipeItem = ({ recipe, onEdit, onDelete, onAdd, isShared }) => {
   const theme = useTheme();
@@ -189,7 +190,7 @@ const Recipes = () => {
       });
       setRecipes(response.data);
     } catch (err) {
-      setError('Failed to fetch recipes. Please try again.');
+      setError(getErrorMessage(err, 'Failed to fetch recipes. Please try again.'));
     }
   };
 
@@ -198,7 +199,7 @@ const Recipes = () => {
       const response = await api.get('/ingredients');
       setIngredients(response.data);
     } catch (err) {
-      setError('Failed to fetch ingredients. Please try again.');
+      setError(getErrorMessage(err, 'Failed to fetch ingredients. Please try again.'));
     }
   };
 
@@ -208,7 +209,7 @@ const Recipes = () => {
       setSharedRecipes(response.data);
     } catch (err) {
       console.error('Error fetching shared recipes:', err);
-      setError('Failed to fetch shared recipes');
+      setError(getErrorMessage(err, 'Failed to fetch shared recipes'));
     }
   };
 
@@ -220,7 +221,7 @@ const Recipes = () => {
         setLoading(true);
         await Promise.all([fetchRecipes(), fetchIngredients()]);
       } catch (err) {
-        setError('Failed to fetch data. Please try again.');
+        setError(getErrorMessage(err, 'Failed to fetch data. Please try again.'));
       } finally {
         setLoading(false);
       }
@@ -253,7 +254,7 @@ const Recipes = () => {
       fetchIngredients(); // ensure ingredients list updated
     } catch (err) {
       console.error('Error duplicating recipe:', err);
-      setError(err.response?.data?.error || 'Failed to add recipe');
+      setError(getErrorMessage(err, 'Failed to add recipe'));
     }
   };
 
@@ -366,13 +367,11 @@ const Recipes = () => {
         const response = await api.get('/recipes');
         setRecipes(response.data);
       } catch (err) {
-        const message = err.response?.data?.message || 'Failed to fetch recipes. Please try again.';
-        setError(message);
+        setError(getErrorMessage(err, 'Failed to fetch recipes. Please try again.'));
       }
     } catch (err) {
       console.error('Error saving recipe:', err);
-      const message = err.response?.data?.message || 'Failed to save recipe. Please try again.';
-      setError(message);
+      setError(getErrorMessage(err, 'Failed to save recipe. Please try again.'));
     }
   };
 
@@ -382,8 +381,7 @@ const Recipes = () => {
       fetchRecipes();
     } catch (err) {
       console.error('Error deleting recipe:', err);
-      const message = err.response?.data?.message || 'Failed to delete recipe. Please try again.';
-      setError(message);
+      setError(getErrorMessage(err, 'Failed to delete recipe. Please try again.'));
     }
   };
 

--- a/foodfornow-frontend/src/pages/ShoppingList.jsx
+++ b/foodfornow-frontend/src/pages/ShoppingList.jsx
@@ -37,6 +37,7 @@ import api from '../services/api';
 import { getCategoryColor } from '../utils/categoryColors';
 import { toast } from 'react-hot-toast';
 import { useAuth } from '../context/AuthContext';
+import { getErrorMessage } from '../utils/errorHandler';
 
 const ShoppingList = () => {
   const theme = useTheme();
@@ -80,7 +81,7 @@ const ShoppingList = () => {
       }
     } catch (err) {
       console.error('Error fetching shopping list:', err);
-      setError('Failed to fetch shopping list');
+      setError(getErrorMessage(err, 'Failed to fetch shopping list'));
     } finally {
       setLoading(false);
     }
@@ -92,7 +93,7 @@ const ShoppingList = () => {
       setIngredients(response.data);
     } catch (err) {
       console.error('Error fetching ingredients:', err);
-      setError('Failed to load ingredients');
+      setError(getErrorMessage(err, 'Failed to load ingredients'));
     }
   };
 
@@ -111,7 +112,7 @@ const ShoppingList = () => {
       fetchShoppingList();
     } catch (err) {
       console.error('Error deleting item:', err);
-      setError('Failed to delete item');
+      setError(getErrorMessage(err, 'Failed to delete item'));
     }
   };
 

--- a/foodfornow-frontend/src/utils/errorHandler.js
+++ b/foodfornow-frontend/src/utils/errorHandler.js
@@ -1,0 +1,9 @@
+export function getErrorMessage(err, fallback = 'An error occurred') {
+  if (err?.response?.data) {
+    if (typeof err.response.data === 'string') return err.response.data;
+    if (err.response.data.error) return err.response.data.error;
+    if (err.response.data.message) return err.response.data.message;
+  }
+  if (err?.message) return err.message;
+  return fallback;
+}


### PR DESCRIPTION
## Summary
- normalize backend error responses for ingredients and shopping list APIs
- expose a `getErrorMessage` helper in the frontend
- use the helper throughout pages to show server-provided error text

## Testing
- `npm run lint -w foodfornow-frontend` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68517c56c9408321b0c2ebd4e2866239