### PR TITLE
Remove localStorage token logic

### DIFF
--- a/foodfornow-frontend/src/services/api.js
+++ b/foodfornow-frontend/src/services/api.js
@@ -57,7 +57,6 @@ api.interceptors.response.use(
         isRefreshing = false;
         refreshSubscribers = [];
         if (typeof window !== 'undefined') {
-          localStorage.removeItem('token');
           window.location.href = '/login';
         }
         return Promise.reject(refreshError);


### PR DESCRIPTION
## Summary
- rely on cookies for authentication token management
- remove obsolete localStorage cleanup

## Testing
- `npm -w foodfornow-frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685391115e108321b1df305d11df0e0d