### PR TITLE
Fix register auth refresh

### DIFF
--- a/foodfornow-frontend/src/pages/Register.jsx
+++ b/foodfornow-frontend/src/pages/Register.jsx
@@ -21,10 +21,12 @@ import {
 } from '@mui/icons-material';
 import PasswordField from '../components/PasswordField';
 import api from '../services/api';
+import { useAuth } from '../context/AuthContext';
 
 const Register = () => {
   const navigate = useNavigate();
   const theme = useTheme();
+  const { refreshAuth } = useAuth();
   const [formData, setFormData] = useState({
     name: '',
     email: '',
@@ -113,6 +115,7 @@ const Register = () => {
         }
       }
 
+      await refreshAuth();
       navigate('/dashboard', { replace: true });
     } catch (err) {
       console.error('Registration error:', err);


### PR DESCRIPTION
## Summary
- allow newly registered users to access private routes by refreshing auth

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6853911327cc832188e0529c193702a2