### PR TITLE
Refactor to use PrivateRoute component

### DIFF
--- a/foodfornow-frontend/src/App.jsx
+++ b/foodfornow-frontend/src/App.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
-import { AuthProvider, useAuth } from './context/AuthContext';
+import { AuthProvider } from './context/AuthContext';
 import { ThemeProvider } from './context/ThemeContext';
 import Navbar from './components/Navbar';
+import PrivateRoute from './components/PrivateRoute';
 import Login from './pages/Login';
 import Register from './pages/Register';
 import Dashboard from './pages/Dashboard';
@@ -13,16 +14,6 @@ import RecipeDetail from './pages/RecipeDetail';
 import Ingredients from './pages/Ingredients';
 import { Toaster } from 'react-hot-toast';
 import Profile from './pages/Profile';
-
-const PrivateRoute = ({ children }) => {
-  const { authenticated, loading } = useAuth();
-
-  if (loading) {
-    return null;
-  }
-
-  return authenticated ? children : <Navigate to="/login" />;
-};
 
 function App() {
   return (


### PR DESCRIPTION
## Summary
- rely on shared `PrivateRoute` component
- remove inline route guard in `App.jsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68539115c1a08321bf419572a2c6627c