### PR TITLE
Add Docker setup and CI build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,7 +3,7 @@ name: Build and Push Docker images
 on:
   push:
     branches: [ main ]
-  pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: tantorski-ffn-runner-set
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,47 @@
+name: Build and Push Docker images
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker image names
+        run: |
+          echo "IMAGE_BACKEND=${{ env.REGISTRY }}/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')-backend" >> $GITHUB_ENV
+          echo "IMAGE_FRONTEND=${{ env.REGISTRY }}/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')-frontend" >> $GITHUB_ENV
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build backend image
+        run: |
+          docker build -t $IMAGE_BACKEND:${{ github.sha }} -t $IMAGE_BACKEND:latest ./foodfornow-backend
+
+      - name: Build frontend image
+        run: |
+          docker build -t $IMAGE_FRONTEND:${{ github.sha }} -t $IMAGE_FRONTEND:latest ./foodfornow-frontend
+
+      - name: Push images
+        if: github.ref == 'refs/heads/main'
+        run: |
+          docker push $IMAGE_BACKEND:${{ github.sha }}
+          docker push $IMAGE_BACKEND:latest
+          docker push $IMAGE_FRONTEND:${{ github.sha }}
+          docker push $IMAGE_FRONTEND:latest

--- a/README.md
+++ b/README.md
@@ -3,6 +3,22 @@
 ## Overview
 FoodForNow is a full-stack web application designed to help users manage their pantry, recipes, and shopping lists. The application is built using React for the frontend and Node.js with Express for the backend.
 
+## Docker Setup
+
+Production deployments can be built using the provided Dockerfiles. Both the
+backend and frontend images can be built locally or via the included GitHub
+Actions workflow which publishes images to GitHub Container Registry.
+
+```bash
+# build and run backend
+docker build -t foodfornow-backend ./foodfornow-backend
+docker run -p 3001:3001 --env-file foodfornow-backend/.env.example foodfornow-backend
+
+# build and run frontend
+docker build -t foodfornow-frontend ./foodfornow-frontend
+docker run -p 8080:80 --env-file foodfornow-frontend/.env.example foodfornow-frontend
+```
+
 ## Features
 - **User Authentication**: Secure login and registration system.
 - **Dashboard**: Overview of user's pantry, recipes, and shopping lists.

--- a/foodfornow-backend/.dockerignore
+++ b/foodfornow-backend/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+.git
+.gitignore
+.env

--- a/foodfornow-backend/.env.example
+++ b/foodfornow-backend/.env.example
@@ -1,0 +1,3 @@
+PORT=3001
+MONGO_URI=mongodb://username:password@host:port/dbname
+CORS_ORIGIN=http://localhost:5173

--- a/foodfornow-backend/Dockerfile
+++ b/foodfornow-backend/Dockerfile
@@ -1,0 +1,13 @@
+# Build a lightweight production image
+FROM node:18-alpine as base
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+# Copy source
+COPY . .
+
+EXPOSE 3001
+CMD ["node", "server.js"]

--- a/foodfornow-backend/Dockerfile
+++ b/foodfornow-backend/Dockerfile
@@ -1,12 +1,22 @@
-# Build a lightweight production image
-FROM node:18-alpine as base
+# Install dependencies with necessary build tools
+FROM node:22-alpine AS deps
 WORKDIR /app
 
-# Install dependencies
-COPY package*.json ./
-RUN npm ci --omit=dev
+# Install system dependencies for bcrypt and native modules
+RUN apk add --no-cache python3 make g++ \
+  && npm config set python python3
 
-# Copy source
+COPY package*.json ./
+RUN npm install --omit=dev
+
+# Final production image
+FROM node:22-alpine
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+# Copy only the built node_modules and app code
+COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
 EXPOSE 3001

--- a/foodfornow-frontend/.dockerignore
+++ b/foodfornow-frontend/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+Dockerfile
+.dockerignore
+.git
+.gitignore
+.env
+*.log

--- a/foodfornow-frontend/.env.example
+++ b/foodfornow-frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3001/api

--- a/foodfornow-frontend/Dockerfile
+++ b/foodfornow-frontend/Dockerfile
@@ -1,14 +1,18 @@
-# Build stage for the React frontend
-FROM node:18-alpine as build
+# Stage 1: Build the frontend
+FROM node:22-alpine AS build
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm ci
+RUN npm install
 COPY . .
 RUN npm run build
 
-# Production stage using nginx to serve static files
+# Stage 2: Serve using nginx
 FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html
+
+# Optional: add cache headers
+# RUN echo 'add_header Cache-Control "public, max-age=31536000, immutable";' > /etc/nginx/conf.d/cache-control.conf
+
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/foodfornow-frontend/Dockerfile
+++ b/foodfornow-frontend/Dockerfile
@@ -1,0 +1,14 @@
+# Build stage for the React frontend
+FROM node:18-alpine as build
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Production stage using nginx to serve static files
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/foodfornow-frontend/src/services/api.js
+++ b/foodfornow-frontend/src/services/api.js
@@ -1,6 +1,11 @@
 import axios from 'axios';
 
-const API_URL = 'http://localhost:3001/api';
+// Use environment variable to configure the backend API URL. During
+// development the value from `.env` will be used and in production the
+// variable can be provided at build time. Fallback to `/api` so the
+// frontend can be served from the same host as the backend when behind a
+// reverse proxy.
+const API_URL = import.meta.env.VITE_API_URL || '/api';
 
 // Create axios instance with default config
 const api = axios.create({


### PR DESCRIPTION
## Summary
- make API URL configurable in frontend
- document Docker build steps
- add example env files
- add Dockerfiles for frontend and backend
- add Docker build/push GitHub Actions workflow

## Testing
- `npm run build -w foodfornow-frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685390e5123c832199694a9eaa510cac